### PR TITLE
feat: audio-support

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,6 +197,71 @@
               <span class="drum__key">C</span>
             </button>
           </div>
+
+          <div class="drum__audio-container" aria-hidden="true">
+            <audio
+              class="drum__audio"
+              data-key="q"
+              src="./assets/media/audio/boom.wav"
+              preload="auto"
+            ></audio>
+
+            <audio
+              class="drum__audio"
+              data-key="w"
+              src="./assets/media/audio/clap.wav"
+              preload="auto"
+            ></audio>
+
+            <audio
+              class="drum__audio"
+              data-key="e"
+              src="./assets/media/audio/hihat.wav"
+              preload="auto"
+            ></audio>
+
+            <audio
+              class="drum__audio"
+              data-key="a"
+              src="./assets/media/audio/kick.wav"
+              preload="auto"
+            ></audio>
+
+            <audio
+              class="drum__audio"
+              data-key="s"
+              src="./assets/media/audio/openhat.wav"
+              preload="auto"
+            ></audio>
+
+            <audio
+              class="drum__audio"
+              data-key="d"
+              src="./assets/media/audio/ride.wav"
+              preload="auto"
+            ></audio>
+
+            <audio
+              class="drum__audio"
+              data-key="z"
+              src="./assets/media/audio/snare.wav"
+              preload="auto"
+            ></audio>
+
+            <audio
+              class="drum__audio"
+              data-key="x"
+              src="./assets/media/audio/tink.wav"
+              preload="auto"
+            ></audio>
+
+            <audio
+              class="drum__audio"
+              data-key="c"
+              src="./assets/media/audio/tom.wav"
+              preload="auto"
+            ></audio>
+          </div>
         </section>
       </div>
     </main>

--- a/index.html
+++ b/index.html
@@ -161,39 +161,39 @@
           </h2>
 
           <div class="drum__container">
-            <button type="button" class="drum__button">
+            <button type="button" class="drum__button" data-key="q">
               <span class="drum__key">Q</span>
             </button>
 
-            <button type="button" class="drum__button">
+            <button type="button" class="drum__button" data-key="w">
               <span class="drum__key">W</span>
             </button>
 
-            <button type="button" class="drum__button">
+            <button type="button" class="drum__button" data-key="e">
               <span class="drum__key">E</span>
             </button>
 
-            <button type="button" class="drum__button">
+            <button type="button" class="drum__button" data-key="a">
               <span class="drum__key">A</span>
             </button>
 
-            <button type="button" class="drum__button">
+            <button type="button" class="drum__button" data-key="s">
               <span class="drum__key">S</span>
             </button>
 
-            <button type="button" class="drum__button">
+            <button type="button" class="drum__button" data-key="d">
               <span class="drum__key">D</span>
             </button>
 
-            <button type="button" class="drum__button">
+            <button type="button" class="drum__button" data-key="z">
               <span class="drum__key">Z</span>
             </button>
 
-            <button type="button" class="drum__button">
+            <button type="button" class="drum__button" data-key="x">
               <span class="drum__key">X</span>
             </button>
 
-            <button type="button" class="drum__button">
+            <button type="button" class="drum__button" data-key="c">
               <span class="drum__key">C</span>
             </button>
           </div>


### PR DESCRIPTION
## Description

Added a hidden audio container with `<audio>` elements and connected them to buttons using `data-key` attributes.

## Changes

- Added an audio container element with `aria-hidden="true"`
- Added nine `<audio>` elements with `preload="auto"`
- Linked audio files and buttons using `data-key` attributes
- Ensured `data-key` values correspond to keyboard keys for drum playback

## Notes for Reviewers

- Verify that `data-key` values are consistent between `<audio>` and `<button>` elements
- Verify that all audio sources load and play correctly
