### PR TITLE
feat(html): add instrument icons to drum buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,38 +162,101 @@
 
           <div class="drum__container">
             <button type="button" class="drum__button" data-key="q">
+              <img
+                src="./assets/icons/boom.svg"
+                alt=""
+                class="drum__icon"
+                width="800"
+                height="800"
+              />
               <span class="drum__key">Q</span>
             </button>
 
             <button type="button" class="drum__button" data-key="w">
+              <img
+                src="./assets/icons/clap.svg"
+                alt=""
+                class="drum__icon"
+                width="800"
+                height="800"
+              />
               <span class="drum__key">W</span>
             </button>
 
             <button type="button" class="drum__button" data-key="e">
+              <img
+                src="./assets/icons/hihat.svg"
+                alt=""
+                class="drum__icon"
+                width="800"
+                height="800"
+              />
               <span class="drum__key">E</span>
             </button>
 
             <button type="button" class="drum__button" data-key="a">
+              <img
+                src="./assets/icons/kick.svg"
+                alt=""
+                class="drum__icon"
+                width="800"
+                height="800"
+              />
               <span class="drum__key">A</span>
             </button>
 
             <button type="button" class="drum__button" data-key="s">
+              <img
+                src="./assets/icons/openhat.svg"
+                alt=""
+                class="drum__icon"
+                width="800"
+                height="800"
+              />
               <span class="drum__key">S</span>
             </button>
 
             <button type="button" class="drum__button" data-key="d">
+              <img
+                src="./assets/icons/ride.svg"
+                alt=""
+                class="drum__icon"
+                width="800"
+                height="800"
+              />
               <span class="drum__key">D</span>
             </button>
 
             <button type="button" class="drum__button" data-key="z">
+              <img
+                src="./assets/icons/snare.svg"
+                alt=""
+                class="drum__icon"
+                width="800"
+                height="800"
+              />
               <span class="drum__key">Z</span>
             </button>
 
             <button type="button" class="drum__button" data-key="x">
+              <img
+                src="./assets/icons/tink.svg"
+                alt=""
+                class="drum__icon"
+                width="800"
+                height="800"
+              />
               <span class="drum__key">X</span>
             </button>
 
             <button type="button" class="drum__button" data-key="c">
+              <img
+                src="./assets/icons/tom.svg"
+                alt=""
+                class="drum__icon"
+                width="800"
+                height="800"
+              />
               <span class="drum__key">C</span>
             </button>
           </div>


### PR DESCRIPTION
## Description

Added all the corresponding drum instrument icons for each `<button>` element.

## Changes

- Added `<img>` elements with a class `drum__icon`
- Used `alt=""` attribute to hide from screen readers

## Notes for Reviewers

- Make sure that the `src` attributes for each `<img>` tag points to the right source path
