### PR TITLE
fix: added guard code for key press errors

### DIFF
--- a/js/modules/drum.js
+++ b/js/modules/drum.js
@@ -1,6 +1,7 @@
 //* DRUM.JS SCRIPT
 const buttons = document.querySelectorAll(".drum__button");
 const sounds = document.querySelectorAll(".drum__audio");
+const keys = ["q", "w", "e", "a", "s", "d", "z", "x", "c"];
 
 function playSound(buttonElement) {
   const currentSound = [...sounds].find(
@@ -26,7 +27,9 @@ function initDrumButtons() {
 
     window.addEventListener("keydown", (e) => {
       const key = e.key;
-      playSoundThruKey(key);
+      if (keys.includes(key)) {
+        playSoundThruKey(key);
+      }
     });
   });
 }


### PR DESCRIPTION
## Description

Added guard code to handle key presses that do not have corresponding `<button>` or `<audio>` elements.

## Changes

- Created a `keys` array containing all valid key values
- Added guard code to check if the pressed key exists in the `keys` array before executing any logic

## Notes for Reviewers

- Test by pressing a key that has no associated `<button>` or `<audio>` and confirm no console errors occur
