### PR TITLE
style: header

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -125,6 +125,10 @@ ol {
   display: none;
 }
 
+.bold {
+  font-weight: 700;
+}
+
 /** || GENERAL STYLES */
 html {
   font-size: var(--FS);

--- a/css/style.css
+++ b/css/style.css
@@ -198,14 +198,27 @@ body {
   color: var(--FONT-COLOR-THEME-ICON-DARK);
 }
 
+.header__container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  padding-block-start: 4rem;
+  margin-block-end: 2rem;
+}
+
 .header__title {
   font-family: var(--FF-TITLE);
   color: var(--FONT-COLOR-HEADER-TITLE);
+  text-align: center;
+  font-size: 2.5rem;
+  letter-spacing: 1;
 }
 
 .header__tagline {
   font-family: var(--FF-BODY);
   color: var(--FONT-COLOR-HEADER-TAGLINE);
+  text-align: center;
+  font-size: 0.875rem;
 }
 
 /** || MAIN */

--- a/css/style.css
+++ b/css/style.css
@@ -137,6 +137,10 @@ body {
   background-image: var(--GRADIENT-BODY);
 }
 
+.container {
+  padding-inline: 1.5rem;
+}
+
 /** || HEADER */
 .theme {
   box-shadow: var(--BOX-SHADOW-THEME);

--- a/index.html
+++ b/index.html
@@ -153,7 +153,10 @@
 
         <h1 class="header__title">Keyboard Warrior</h1>
 
-        <p class="header__tagline">Smash the keys, feel the beat</p>
+        <p class="header__tagline">
+          Smash the <span class="bold">keys</span>, feel the
+          <span class="bold">beat</span>
+        </p>
       </div>
     </header>
 


### PR DESCRIPTION
## Description

Added base styles for the `<header>` section including container, title, tagline, and utility classes.

## Changes

- Added utility class `.container` styled with `padding-inline` for layout consistency
- Styled header container, title, and tagline with base typography and spacing
- Updated HTML to wrap part of the tagline with `<span class="bold">`
- Added utility class `.bold` with `font-weight: 700`

## Screenshots

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| ![Before screenshot](https://github.com/user-attachments/assets/40c49268-ec4f-489e-8af5-ca8f8a194205) | ![After screenshot](https://github.com/user-attachments/assets/a004be7a-85e6-4fc0-80fa-8c2719d4fe2b) |


## Notes for Reviewers

- Confirm that the `.container` utility applies correctly without breaking existing layouts
- Check that the `.bold` utility is scoped appropriately
- Ensure that header typography aligns with best practices
