### PR TITLE
feat(html): add aria label to drum buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,12 @@
           </h2>
 
           <div class="drum__container">
-            <button type="button" class="drum__button" data-key="q">
+            <button
+              type="button"
+              class="drum__button"
+              data-key="q"
+              aria-label="Press Q or click on button to play boom"
+            >
               <svg
                 class="drum__icon"
                 aria-hidden="true"
@@ -223,7 +228,12 @@
               <span class="drum__key">Q</span>
             </button>
 
-            <button type="button" class="drum__button" data-key="w">
+            <button
+              type="button"
+              class="drum__button"
+              data-key="w"
+              aria-label="Press W or click on button to play clap"
+            >
               <svg
                 class="drum__icon"
                 aria-hidden="true"
@@ -254,7 +264,12 @@
               <span class="drum__key">W</span>
             </button>
 
-            <button type="button" class="drum__button" data-key="e">
+            <button
+              type="button"
+              class="drum__button"
+              data-key="e"
+              aria-label="Press E or click on button to play hihat"
+            >
               <svg
                 class="drum__icon"
                 aria-hidden="true"
@@ -294,7 +309,12 @@
               <span class="drum__key">E</span>
             </button>
 
-            <button type="button" class="drum__button" data-key="a">
+            <button
+              type="button"
+              class="drum__button"
+              data-key="a"
+              aria-label="Press A or click on button to play kick"
+            >
               <svg
                 class="drum__icon"
                 aria-hidden="true"
@@ -332,7 +352,12 @@
               <span class="drum__key">A</span>
             </button>
 
-            <button type="button" class="drum__button" data-key="s">
+            <button
+              type="button"
+              class="drum__button"
+              data-key="s"
+              aria-label="Press S or click on button to play openhat"
+            >
               <svg
                 class="drum__icon"
                 aria-hidden="true"
@@ -372,7 +397,12 @@
               <span class="drum__key">S</span>
             </button>
 
-            <button type="button" class="drum__button" data-key="d">
+            <button
+              type="button"
+              class="drum__button"
+              data-key="d"
+              aria-label="Press D or click on button to play ride"
+            >
               <svg
                 class="drum__icon"
                 aria-hidden="true"
@@ -411,7 +441,12 @@
               <span class="drum__key">D</span>
             </button>
 
-            <button type="button" class="drum__button" data-key="z">
+            <button
+              type="button"
+              class="drum__button"
+              data-key="z"
+              aria-label="Press Z or click on button to play snare"
+            >
               <svg
                 class="drum__icon"
                 aria-hidden="true"
@@ -486,7 +521,12 @@
               <span class="drum__key">Z</span>
             </button>
 
-            <button type="button" class="drum__button" data-key="x">
+            <button
+              type="button"
+              class="drum__button"
+              data-key="x"
+              aria-label="Press X or click on button to play tink"
+            >
               <svg
                 class="drum__icon"
                 aria-hidden="true"
@@ -507,7 +547,12 @@
               <span class="drum__key">X</span>
             </button>
 
-            <button type="button" class="drum__button" data-key="c">
+            <button
+              type="button"
+              class="drum__button"
+              data-key="c"
+              aria-label="Press C or click on button to play tom"
+            >
               <svg
                 class="drum__icon"
                 aria-hidden="true"


### PR DESCRIPTION
## Description

Added ARIA labels for each button for accessibility.

## Changes

- Added `aria-label` for each drum button

## Notes for Reviewers

- Verify if each `aria-label` corresponds to the correct drum key
