### PR TITLE
style(html): update site meta preview images to dark

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
     />
     <meta
       property="og:image"
-      content="https://keyboard-warrior-jiro.netlify.app/assets/img/site-preview-meta_1200x630.png"
+      content="https://keyboard-warrior-jiro.netlify.app/assets/img/site-preview-meta-dark_1200x630.png"
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Keyboard Warrior" />
@@ -47,7 +47,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://keyboard-warrior-jiro.netlify.app/assets/img/site-preview-meta_1200x630.png"
+      content="https://keyboard-warrior-jiro.netlify.app/assets/img/site-preview-meta-dark_1200x630.png"
     />
     <meta name="color-scheme" content="light dark" />
     <meta


### PR DESCRIPTION
## Description

Updated the meta image site preview to dark themed.

## Changes

- Updated `<meta name="og:image">` and `<meta name="twitter:image">` image content to `https://keyboard-warrior-jiro.netlify.app/assets/img/site-preview-meta-dark_1200x630.png`

## Notes for Reviewers

- Verify if site preview for meta is now dark themed.
